### PR TITLE
Bump Keycloak and katta-server after merge from upstream.

### DIFF
--- a/hub/src/test/resources/.env
+++ b/hub/src/test/resources/.env
@@ -1,4 +1,4 @@
-KATTA_SERVER_IMAGE=ghcr.io/shift7-ch/katta-server:commit-a84ff375700fb73266ff441157d36c628c41d61e-ci
+KATTA_SERVER_IMAGE=ghcr.io/shift7-ch/katta-server:commit-8a067830fbca3765b9377ffdfd706eb7195f8def-ci
 HUB_PORT=8080
 HUB_KEYCLOAK_URL=http://localhost:8180
 HUB_KEYCLOAK_BASEPATH=
@@ -13,7 +13,7 @@ MINIO_HOSTNAME=localhost
 MINIO_PORT=9000
 MINIO_CONSOLE_PORT=9001
 
-KATTA_KEYCLOAK_IMAGE=ghcr.io/cryptomator/keycloak:26.2.2
+KATTA_KEYCLOAK_IMAGE=ghcr.io/cryptomator/keycloak:26.4.5
 KEYCLOAK_HOSTNAME=localhost
 KEYCLOAK_HTTP_PORT=8180
 KEYCLOAK_HTTPS_PORT=8443

--- a/hub/src/test/resources/.hybrid.env
+++ b/hub/src/test/resources/.hybrid.env
@@ -1,4 +1,4 @@
-KATTA_SERVER_IMAGE=ghcr.io/shift7-ch/katta-server:commit-a84ff375700fb73266ff441157d36c628c41d61e-ci
+KATTA_SERVER_IMAGE=ghcr.io/shift7-ch/katta-server:commit-8a067830fbca3765b9377ffdfd706eb7195f8def-ci
 HUB_PORT=8280
 HUB_KEYCLOAK_URL=https://testing.katta.cloud
 HUB_KEYCLOAK_BASEPATH=/kc

--- a/hub/src/test/resources/.local.env
+++ b/hub/src/test/resources/.local.env
@@ -1,4 +1,4 @@
-KATTA_SERVER_IMAGE=ghcr.io/shift7-ch/katta-server:commit-a84ff375700fb73266ff441157d36c628c41d61e-ci
+KATTA_SERVER_IMAGE=ghcr.io/shift7-ch/katta-server:commit-8a067830fbca3765b9377ffdfd706eb7195f8def-ci
 HUB_PORT=8280
 HUB_KEYCLOAK_URL=http://localhost:8380
 HUB_KEYCLOAK_BASEPATH=
@@ -13,7 +13,7 @@ MINIO_HOSTNAME=localhost
 MINIO_PORT=9100
 MINIO_CONSOLE_PORT=9101
 
-KATTA_KEYCLOAK_IMAGE=ghcr.io/cryptomator/keycloak:26.2.2
+KATTA_KEYCLOAK_IMAGE=ghcr.io/cryptomator/keycloak:26.4.5
 KEYCLOAK_HOSTNAME=localhost
 KEYCLOAK_HTTP_PORT=8380
 KEYCLOAK_HTTPS_PORT=8443


### PR DESCRIPTION
Versions from https://github.com/shift7-ch/katta-server/actions/runs/19335710841/job/55310005174. Relates to 

- [x] shift7-ch/katta-server#94