### PR TITLE
Speed up AdminCLI ITs.

### DIFF
--- a/admin-cli/src/test/java/cloud/katta/testsetup/AbstractAdminCLIIT.java
+++ b/admin-cli/src/test/java/cloud/katta/testsetup/AbstractAdminCLIIT.java
@@ -4,24 +4,11 @@
 
 package cloud.katta.testsetup;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.testcontainers.containers.ComposeContainer;
-import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 
-import java.io.File;
-import java.io.IOException;
 import java.net.URI;
-import java.net.URISyntaxException;
-import java.time.Duration;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
-import java.util.stream.Collectors;
 
 import cloud.katta.client.ApiClient;
 import cloud.katta.client.ApiException;
@@ -31,39 +18,8 @@ import cloud.katta.client.auth.HttpBearerAuth;
 import static io.restassured.RestAssured.given;
 
 public class AbstractAdminCLIIT {
-    private static final Logger log = LogManager.getLogger(AbstractAdminCLIIT.class.getName());
-    public static ComposeContainer compose;
-
     protected String accessToken;
     protected ApiClient apiClient;
-
-    @BeforeAll
-    public static void setupDocker() throws URISyntaxException, IOException {
-        final String composeFile = "/docker-compose-minio-localhost-hub.yml";
-        final String envFile = "/.local.env";
-        final String profile = "local";
-        final String hubAdminUser = "admin";
-        final String hubAdminPassword = "admin";
-        final String hubKeycloakSystemClientSecret = "top-secret";
-        final Properties props = new Properties();
-        props.load(AbstractAdminCLIIT.class.getResourceAsStream(envFile));
-        final HashMap<String, String> env = props.entrySet().stream().collect(
-                Collectors.toMap(
-                        e -> String.valueOf(e.getKey()),
-                        e -> String.valueOf(e.getValue()),
-                        (prev, next) -> next, HashMap::new
-                ));
-        env.put("HUB_ADMIN_USER", hubAdminUser);
-        env.put("HUB_ADMIN_PASSWORD", hubAdminPassword);
-        env.put("HUB_KEYCLOAK_SYSTEM_CLIENT_SECRET", hubKeycloakSystemClientSecret);
-        compose = new ComposeContainer(
-                new File(AbstractAdminCLIIT.class.getResource(composeFile).toURI()))
-                .withPull(true)
-                .withEnv(env)
-                .withOptions(profile == null ? "" : String.format("--profile=%s", profile))
-                .waitingFor("minio_setup-1", new LogMessageWaitStrategy().withRegEx(".*Completed MinIO Setup.*").withStartupTimeout(Duration.ofMinutes(2)));
-        compose.start();
-    }
 
     @BeforeEach
     protected void setup() throws Exception {
@@ -87,15 +43,5 @@ public class AbstractAdminCLIIT {
             }
         };
         apiClient.setBasePath("http://localhost:8280");
-    }
-
-    @AfterAll
-    public static void teardownDocker() {
-        try {
-            compose.stop();
-        }
-        catch(Exception e) {
-            log.warn(e);
-        }
     }
 }

--- a/admin-cli/src/test/java/cloud/katta/testsetup/AdminCLIIntegrationTestSetupListener.java
+++ b/admin-cli/src/test/java/cloud/katta/testsetup/AdminCLIIntegrationTestSetupListener.java
@@ -22,7 +22,7 @@ import java.util.stream.Collectors;
 
 public class AdminCLIIntegrationTestSetupListener implements TestExecutionListener {
     private static final Logger log = LogManager.getLogger(AdminCLIIntegrationTestSetupListener.class);
-    private static ComposeContainer<?> compose;
+    private static ComposeContainer compose;
 
 
     @Override

--- a/admin-cli/src/test/java/cloud/katta/testsetup/AdminCLIIntegrationTestSetupListener.java
+++ b/admin-cli/src/test/java/cloud/katta/testsetup/AdminCLIIntegrationTestSetupListener.java
@@ -21,8 +21,8 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 
 public class AdminCLIIntegrationTestSetupListener implements TestExecutionListener {
-    private static final Logger log = LogManager.getLogger(AbstractAdminCLIIT.class.getName());
-    public static ComposeContainer compose;
+    private static final Logger log = LogManager.getLogger(AdminCLIIntegrationTestSetupListener.class);
+    private static ComposeContainer<?> compose;
 
 
     @Override
@@ -59,7 +59,7 @@ public class AdminCLIIntegrationTestSetupListener implements TestExecutionListen
                         new File(AbstractAdminCLIIT.class.getResource(composeFile).toURI()))
                         .withPull(true)
                         .withEnv(env)
-                        .withOptions(profile == null ? "" : String.format("--profile=%s", profile))
+                        .withOptions(String.format("--profile=%s", profile))
                         .waitingFor("minio_setup-1", new LogMessageWaitStrategy().withRegEx(".*Completed MinIO Setup.*").withStartupTimeout(Duration.ofMinutes(2)));
             }
             catch(URISyntaxException e) {
@@ -77,7 +77,7 @@ public class AdminCLIIntegrationTestSetupListener implements TestExecutionListen
             }
         }
         catch(Exception e) {
-            log.warn(e);
+            log.warn("Failed to stop docker-compose test environment", e);
         }
     }
 }

--- a/admin-cli/src/test/java/cloud/katta/testsetup/AdminCLIIntegrationTestSetupListener.java
+++ b/admin-cli/src/test/java/cloud/katta/testsetup/AdminCLIIntegrationTestSetupListener.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2026 shift7 GmbH. All rights reserved.
+ */
+
+package cloud.katta.testsetup;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.platform.engine.TestTag;
+import org.junit.platform.launcher.TestExecutionListener;
+import org.junit.platform.launcher.TestPlan;
+import org.testcontainers.containers.ComposeContainer;
+import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Properties;
+import java.util.stream.Collectors;
+
+public class AdminCLIIntegrationTestSetupListener implements TestExecutionListener {
+    private static final Logger log = LogManager.getLogger(AbstractAdminCLIIT.class.getName());
+    public static ComposeContainer compose;
+
+
+    @Override
+    public void testPlanExecutionStarted(TestPlan testPlan) {
+        if(testPlan.getRoots().stream()
+                .flatMap(root -> testPlan.getChildren(root).stream())
+                .filter(ti -> ti.getTags().contains(TestTag.create("cli")))
+                .findAny().isPresent()) {
+
+            final String composeFile = "/docker-compose-minio-localhost-hub.yml";
+            final String envFile = "/.local.env";
+            final String profile = "local";
+            final String hubAdminUser = "admin";
+            final String hubAdminPassword = "admin";
+            final String hubKeycloakSystemClientSecret = "top-secret";
+            final Properties props = new Properties();
+            try {
+                props.load(AbstractAdminCLIIT.class.getResourceAsStream(envFile));
+            }
+            catch(IOException e) {
+                throw new RuntimeException(e);
+            }
+            final HashMap<String, String> env = props.entrySet().stream().collect(
+                    Collectors.toMap(
+                            e -> String.valueOf(e.getKey()),
+                            e -> String.valueOf(e.getValue()),
+                            (prev, next) -> next, HashMap::new
+                    ));
+            env.put("HUB_ADMIN_USER", hubAdminUser);
+            env.put("HUB_ADMIN_PASSWORD", hubAdminPassword);
+            env.put("HUB_KEYCLOAK_SYSTEM_CLIENT_SECRET", hubKeycloakSystemClientSecret);
+            try {
+                compose = new ComposeContainer(
+                        new File(AbstractAdminCLIIT.class.getResource(composeFile).toURI()))
+                        .withPull(true)
+                        .withEnv(env)
+                        .withOptions(profile == null ? "" : String.format("--profile=%s", profile))
+                        .waitingFor("minio_setup-1", new LogMessageWaitStrategy().withRegEx(".*Completed MinIO Setup.*").withStartupTimeout(Duration.ofMinutes(2)));
+            }
+            catch(URISyntaxException e) {
+                throw new RuntimeException(e);
+            }
+            compose.start();
+        }
+    }
+
+    @Override
+    public void testPlanExecutionFinished(TestPlan testPlan) {
+        try {
+            if(compose != null) {
+                compose.stop();
+            }
+        }
+        catch(Exception e) {
+            log.warn(e);
+        }
+    }
+}

--- a/admin-cli/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
+++ b/admin-cli/src/test/resources/META-INF/services/org.junit.platform.launcher.TestExecutionListener
@@ -1,0 +1,5 @@
+#
+# Copyright (c) 2026 shift7 GmbH. All rights reserved.
+#
+
+cloud.katta.testsetup.AdminCLIIntegrationTestSetupListener


### PR DESCRIPTION
Speed up AdminCLI ITs by implementing TestExecutionListener to setup/teardown Katta Server for all AdminCLI IT only once.