### PR TITLE
Read automatic access grant and WoT settings from `/api/settings`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@ Features:
 
 ## Dev Setup
 
+### Unit tests
+
+Run unit tests only:
+
+```shell
+mvn clean verify -DskipITs
+```
+
+### Debug logging
+
 In order to run a single integration test with debug logging, use
 
 ```shell

--- a/hub/src/main/java/cloud/katta/crypto/uvf/VaultMetadataAutomaticAccessGrantDto.java
+++ b/hub/src/main/java/cloud/katta/crypto/uvf/VaultMetadataAutomaticAccessGrantDto.java
@@ -21,7 +21,7 @@ import io.swagger.annotations.ApiModelProperty;
 
 @JsonPropertyOrder({
         VaultMetadataAutomaticAccessGrantDto.JSON_PROPERTY_ENABLED,
-        VaultMetadataAutomaticAccessGrantDto.JSON_PROPERTY_MAX_WOT_DEPTH
+        VaultMetadataAutomaticAccessGrantDto.JSON_PROPERTY_TRUST_THRESHOLD
 })
 @com.fasterxml.jackson.annotation.JsonIgnoreProperties(ignoreUnknown = true)
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
@@ -30,8 +30,8 @@ public class VaultMetadataAutomaticAccessGrantDto {
     public static final String JSON_PROPERTY_ENABLED = "enabled";
     private Boolean enabled;
 
-    public static final String JSON_PROPERTY_MAX_WOT_DEPTH = "maxWotDepth";
-    private Integer maxWotDepth;
+    public static final String JSON_PROPERTY_TRUST_THRESHOLD = "trustThreshold";
+    private Integer trustThreshold;
 
     public VaultMetadataAutomaticAccessGrantDto() {
     }
@@ -41,7 +41,6 @@ public class VaultMetadataAutomaticAccessGrantDto {
         return this;
     }
 
-    @javax.annotation.Nullable
     @ApiModelProperty(value = "")
     @JsonProperty(JSON_PROPERTY_ENABLED)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -55,24 +54,23 @@ public class VaultMetadataAutomaticAccessGrantDto {
         this.enabled = enabled;
     }
 
-    public VaultMetadataAutomaticAccessGrantDto maxWotDepth(Integer maxWotDepth) {
-        this.maxWotDepth = maxWotDepth;
+    public VaultMetadataAutomaticAccessGrantDto trustThreshold(Integer trustThreshold) {
+        this.trustThreshold = trustThreshold;
         return this;
     }
 
-    @javax.annotation.Nullable
     @ApiModelProperty(value = "")
-    @JsonProperty(JSON_PROPERTY_MAX_WOT_DEPTH)
+    @JsonProperty(JSON_PROPERTY_TRUST_THRESHOLD)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-    public Integer getMaxWotDepth() {
-        return maxWotDepth;
+    public Integer getTrustThreshold() {
+        return trustThreshold;
     }
 
 
-    @JsonProperty(JSON_PROPERTY_MAX_WOT_DEPTH)
+    @JsonProperty(JSON_PROPERTY_TRUST_THRESHOLD)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-    public void setMaxWotDepth(Integer maxWotDepth) {
-        this.maxWotDepth = maxWotDepth;
+    public void setTrustThreshold(Integer trustThreshold) {
+        this.trustThreshold = trustThreshold;
     }
 
     @Override
@@ -85,19 +83,19 @@ public class VaultMetadataAutomaticAccessGrantDto {
         }
         VaultMetadataAutomaticAccessGrantDto vaultMetadataJWEAutomaticAccessGrantDto = (VaultMetadataAutomaticAccessGrantDto) o;
         return Objects.equals(this.enabled, vaultMetadataJWEAutomaticAccessGrantDto.enabled) &&
-                Objects.equals(this.maxWotDepth, vaultMetadataJWEAutomaticAccessGrantDto.maxWotDepth);
+                Objects.equals(this.trustThreshold, vaultMetadataJWEAutomaticAccessGrantDto.trustThreshold);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(enabled, maxWotDepth);
+        return Objects.hash(enabled, trustThreshold);
     }
 
     @Override
     public String toString() {
         final StringBuilder sb = new StringBuilder("VaultMetadataAutomaticAccessGrantDto{");
         sb.append("enabled=").append(enabled);
-        sb.append(", maxWotDepth=").append(maxWotDepth);
+        sb.append(", trustThreshold=").append(trustThreshold);
         sb.append('}');
         return sb.toString();
     }

--- a/hub/src/main/java/cloud/katta/crypto/uvf/VaultMetadataAutomaticAccessGrantDto.java
+++ b/hub/src/main/java/cloud/katta/crypto/uvf/VaultMetadataAutomaticAccessGrantDto.java
@@ -26,6 +26,7 @@ import io.swagger.annotations.ApiModelProperty;
 @com.fasterxml.jackson.annotation.JsonIgnoreProperties(ignoreUnknown = true)
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class VaultMetadataAutomaticAccessGrantDto {
+
     public static final String JSON_PROPERTY_ENABLED = "enabled";
     private Boolean enabled;
 
@@ -40,20 +41,13 @@ public class VaultMetadataAutomaticAccessGrantDto {
         return this;
     }
 
-    /**
-     * Get enabled
-     *
-     * @return enabled
-     **/
     @javax.annotation.Nullable
     @ApiModelProperty(value = "")
     @JsonProperty(JSON_PROPERTY_ENABLED)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-
     public Boolean getEnabled() {
         return enabled;
     }
-
 
     @JsonProperty(JSON_PROPERTY_ENABLED)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
@@ -61,22 +55,15 @@ public class VaultMetadataAutomaticAccessGrantDto {
         this.enabled = enabled;
     }
 
-
     public VaultMetadataAutomaticAccessGrantDto maxWotDepth(Integer maxWotDepth) {
         this.maxWotDepth = maxWotDepth;
         return this;
     }
 
-    /**
-     * Get maxWotDepth
-     *
-     * @return maxWotDepth
-     **/
     @javax.annotation.Nullable
     @ApiModelProperty(value = "")
     @JsonProperty(JSON_PROPERTY_MAX_WOT_DEPTH)
     @JsonInclude(value = JsonInclude.Include.USE_DEFAULTS)
-
     public Integer getMaxWotDepth() {
         return maxWotDepth;
     }
@@ -88,10 +75,6 @@ public class VaultMetadataAutomaticAccessGrantDto {
         this.maxWotDepth = maxWotDepth;
     }
 
-
-    /**
-     * Return true if this AutomaticAccessGrant object is equal to o.
-     */
     @Override
     public boolean equals(Object o) {
         if(this == o) {

--- a/hub/src/main/java/cloud/katta/crypto/uvf/VaultMetadataAutomaticAccessGrantDto.java
+++ b/hub/src/main/java/cloud/katta/crypto/uvf/VaultMetadataAutomaticAccessGrantDto.java
@@ -112,24 +112,11 @@ public class VaultMetadataAutomaticAccessGrantDto {
 
     @Override
     public String toString() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("class AutomaticAccessGrant {\n");
-        sb.append("    enabled: ").append(toIndentedString(enabled)).append("\n");
-        sb.append("    maxWotDepth: ").append(toIndentedString(maxWotDepth)).append("\n");
-        sb.append("}");
+        final StringBuilder sb = new StringBuilder("VaultMetadataAutomaticAccessGrantDto{");
+        sb.append("enabled=").append(enabled);
+        sb.append(", maxWotDepth=").append(maxWotDepth);
+        sb.append('}');
         return sb.toString();
     }
-
-    /**
-     * Convert the given object to string with each line indented by 4 spaces
-     * (except the first line).
-     */
-    private String toIndentedString(Object o) {
-        if(o == null) {
-            return "null";
-        }
-        return o.toString().replace("\n", "\n    ");
-    }
-
 }
 

--- a/hub/src/main/java/cloud/katta/protocols/hub/HubStorageLocationService.java
+++ b/hub/src/main/java/cloud/katta/protocols/hub/HubStorageLocationService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2025 shift7 GmbH. All rights reserved.
+ * Copyright (c) 2026 shift7 GmbH. All rights reserved.
  */
 
 package cloud.katta.protocols.hub;
@@ -19,6 +19,7 @@ import java.util.Set;
 
 import cloud.katta.client.ApiException;
 import cloud.katta.client.api.StorageProfileResourceApi;
+import cloud.katta.client.model.SettingsDto;
 import cloud.katta.client.model.StorageProfileDto;
 import cloud.katta.crypto.uvf.UVFMetadataPayload;
 import cloud.katta.crypto.uvf.VaultMetadataAutomaticAccessGrantDto;
@@ -120,16 +121,17 @@ public class HubStorageLocationService implements Location {
             return new StorageLocation(storage.getProvider(), storage.getRegion(), storage.getNickname());
         }
 
-        public UVFMetadataPayload toPayload(final Path bucket) {
-            return this.toPayload(bucket, new Credentials(null, null));
+        public UVFMetadataPayload toPayload(final Path bucket, final SettingsDto settings) {
+            return this.toPayload(bucket, new Credentials(null, null), settings);
         }
 
         /**
          * Create UVF Metadata Payload
          *
          * @param credentials Static credentials for storage access
+         * @param settings Katta Server settings
          */
-        public UVFMetadataPayload toPayload(final Path bucket, final Credentials credentials) {
+        public UVFMetadataPayload toPayload(final Path bucket, final Credentials credentials, final SettingsDto settings) {
             return UVFMetadataPayload.create()
                     .withStorage(new VaultMetadataStorageDto()
                             .username(credentials.getUsername()).password(credentials.getPassword())
@@ -138,8 +140,8 @@ public class HubStorageLocationService implements Location {
                             .region(region)
                             .nickname(bucket.attributes().getDisplayname()))
                     .withAutomaticAccessGrant(new VaultMetadataAutomaticAccessGrantDto()
-                            .enabled(true)
-                            .maxWotDepth(-1));
+                            .enabled(settings.getEnableAutomaticAccessGrant())
+                            .maxWotDepth(settings.getAutomaticAccessGrantTrustThreshold()));
         }
     }
 }

--- a/hub/src/main/java/cloud/katta/protocols/hub/HubStorageLocationService.java
+++ b/hub/src/main/java/cloud/katta/protocols/hub/HubStorageLocationService.java
@@ -141,7 +141,7 @@ public class HubStorageLocationService implements Location {
                             .nickname(bucket.attributes().getDisplayname()))
                     .withAutomaticAccessGrant(new VaultMetadataAutomaticAccessGrantDto()
                             .enabled(settings.getEnableAutomaticAccessGrant())
-                            .maxWotDepth(settings.getAutomaticAccessGrantTrustThreshold()));
+                            .trustThreshold(settings.getAutomaticAccessGrantTrustThreshold()));
         }
     }
 }

--- a/hub/src/main/java/cloud/katta/protocols/hub/HubUVFVaultProvider.java
+++ b/hub/src/main/java/cloud/katta/protocols/hub/HubUVFVaultProvider.java
@@ -47,8 +47,10 @@ import java.util.EnumSet;
 import java.util.UUID;
 
 import cloud.katta.client.ApiException;
+import cloud.katta.client.api.SettingsResourceApi;
 import cloud.katta.client.api.StorageProfileResourceApi;
 import cloud.katta.client.api.VaultResourceApi;
+import cloud.katta.client.model.SettingsDto;
 import cloud.katta.client.model.UserDto;
 import cloud.katta.client.model.VaultDto;
 import cloud.katta.core.DeviceSetupCallback;
@@ -97,6 +99,8 @@ public class HubUVFVaultProvider implements VaultProvider {
                     new DefaultPathAttributes()
                             .setRegion(region)
                             .setDisplayname(name.getName()));
+            final SettingsResourceApi settingsResourceApi = new SettingsResourceApi(HubSession.coerce(session).getClient());
+            final SettingsDto settings = settingsResourceApi.apiSettingsGet();
             final UVFMetadataPayload payload;
             switch(storageProfile.getProtocol()) {
                 case S3_STATIC: {
@@ -108,7 +112,7 @@ public class HubUVFVaultProvider implements VaultProvider {
                                     .password(true)
                                     .save(false));
                     log.debug("Use static S3 credentials for vault {}", vaultId);
-                    payload = location.toPayload(bucket, credentials);
+                    payload = location.toPayload(bucket, credentials, settings);
                     storage = new S3Session(new Host(new HubStorageProfile(
                             new S3Protocol(), HubSession.coerce(session).getConfig(), storageProfile), credentials).setRegion(location.getRegion()),
                             session.getFeature(X509TrustManager.class), session.getFeature(X509KeyManager.class));
@@ -130,7 +134,7 @@ public class HubUVFVaultProvider implements VaultProvider {
                             return super.getProperty(key);
                         }
                     }.setRegion(location.getRegion());
-                    payload = location.toPayload(bucket);
+                    payload = location.toPayload(bucket, settings);
                     storage = new S3Session(host, session.getFeature(X509TrustManager.class), session.getFeature(X509KeyManager.class)) {
                         @Override
                         protected S3CredentialsStrategy configureCredentialsStrategy(final HttpClientBuilder configuration, final LoginCallback prompt) {

--- a/hub/src/main/java/cloud/katta/protocols/hub/HubUVFVaultProvider.java
+++ b/hub/src/main/java/cloud/katta/protocols/hub/HubUVFVaultProvider.java
@@ -99,8 +99,7 @@ public class HubUVFVaultProvider implements VaultProvider {
                     new DefaultPathAttributes()
                             .setRegion(region)
                             .setDisplayname(name.getName()));
-            final SettingsResourceApi settingsResourceApi = new SettingsResourceApi(HubSession.coerce(session).getClient());
-            final SettingsDto settings = settingsResourceApi.apiSettingsGet();
+            final SettingsDto settings = new SettingsResourceApi(HubSession.coerce(session).getClient()).apiSettingsGet();
             final UVFMetadataPayload payload;
             switch(storageProfile.getProtocol()) {
                 case S3_STATIC: {

--- a/hub/src/main/java/cloud/katta/workflows/GrantAccessServiceImpl.java
+++ b/hub/src/main/java/cloud/katta/workflows/GrantAccessServiceImpl.java
@@ -60,8 +60,8 @@ public class GrantAccessServiceImpl implements GrantAccessService {
                 return;
             }
             // 1. Get Ids of trusted and verified users
-            // maxWotDepth: -1 means "grant to anyone", where 0, 1, 2 would be the number of edges between any vault owner and the grantee.
-            final int maxWotDepth = ofNullable(vaultMetadata.automaticAccessGrant().getMaxWotDepth()).orElse(-1);
+            // trustThreshold: -1 means "grant to anyone", where 0, 1, 2 would be the number of edges between any vault owner and the grantee.
+            final int trustThreshold = ofNullable(vaultMetadata.automaticAccessGrant().getTrustThreshold()).orElse(-1);
             final Map<String, Integer> verifiedTrustedUsers = woTService.getTrustLevelsPerUserId(userKeys);
             // 2. For users, who are considered trustworthy (i.e. the signature chain between the current user and the to-be-trusted user is shorter
             // than a configurable threshold), use the verified ECDH public key to encrypt the vault's member key (and optionally its recovery key):
@@ -73,15 +73,15 @@ public class GrantAccessServiceImpl implements GrantAccessService {
                     log.debug("Ignoring user {} for vault {} - no user key yet", user.getId(), vaultId);
                     continue;
                 }
-                if(maxWotDepth >= 0) {
+                if(trustThreshold >= 0) {
                     final Integer trustLevel = verifiedTrustedUsers.get(user.getId());
                     if(trustLevel == null) {
                         log.warn("Ignoring user {} for vault {} - no trust level", user.getId(), vaultId);
                         continue;
                     }
-                    // trustLevel must be <= maxWotDepth for automatic access grant
-                    if(trustLevel > maxWotDepth) {
-                        log.warn("Ignoring user {} for vault {} - not verified (trust level {} > maxWotDepth {})", user.getId(), vaultId, trustLevel, maxWotDepth);
+                    // trustLevel must be <= trustThreshold for automatic access grant
+                    if(trustLevel > trustThreshold) {
+                        log.warn("Ignoring user {} for vault {} - not verified (trust level {} > trustThreshold {})", user.getId(), vaultId, trustLevel, trustThreshold);
                         continue;
                     }
                 }

--- a/hub/src/main/java/cloud/katta/workflows/WoTServiceImpl.java
+++ b/hub/src/main/java/cloud/katta/workflows/WoTServiceImpl.java
@@ -59,7 +59,8 @@ public class WoTServiceImpl implements WoTService {
             return Collections.emptyMap();
         }
 
-        final List<UserDto> users = authorityApi.apiAuthoritiesGet(trusts.stream().map(TrustedUserDto::getTrustedUserId).filter(Objects::nonNull).collect(Collectors.toList())).stream().map(AuthorityDto::getUserDto).collect(Collectors.toList());
+        final List<UserDto> users = authorityApi.apiAuthoritiesGet(trusts.stream().map(TrustedUserDto::getTrustedUserId).filter(Objects::nonNull)
+                .collect(Collectors.toList())).stream().map(AuthorityDto::getUserDto).collect(Collectors.toList());
 
         // 2. Verify all returned signature chains
         return WoT.verifyTrusts(trusts, users, signerPublicKey);

--- a/hub/src/test/java/cloud/katta/protocols/hub/HubVaultMetadataUVFProviderTest.java
+++ b/hub/src/test/java/cloud/katta/protocols/hub/HubVaultMetadataUVFProviderTest.java
@@ -100,21 +100,21 @@ class HubVaultMetadataUVFProviderTest {
     @Test
     void testDecrypt() throws Exception {
         // https://datatracker.ietf.org/doc/html/rfc7516#section-7.2.1
-        final JWKSet jwks = JWKSet.parse("{\"keys\":[{\"kty\":\"oct\",\"kid\":\"org.cryptomator.hub.memberkey\",\"k\":\"dp5yWgrqhBNarwOEFDCXKv4h3lUf2pYKCCsXy-6TXDA\",\"alg\":\"A256KW\"}, {\"kty\":\"EC\",\"d\":\"8jz0iHA1jcp2dTB8NkVzTrDjpNhLeqfjLh-6iC2kWpc1VI-tMfK8T7gYjoNDJDDi\",\"crv\":\"P-384\",\"kid\":\"org.cryptomator.hub.recoverykey.2ZXISh-HhVaChehjaOZ6_n5Xl20fy6oAIkIrKkmMuNc\",\"x\":\"C1BXM5oQgz5AsfI7NblbYKMysWO72bQEbXbS7stgypKRxlOn4VQXQ2NkuFu0Ygom\",\"y\":\"7o8Wxe5efN-CXNsm8qe7prohViSl7a4TB8ilF5QHEh2vlIcJ5OXT2MZQyVXUZABo\",\"alg\":\"ECDH-ES+A256KW\"}]}");
+        final JWKSet jwks = JWKSet.parse("{\"keys\":[{\"kty\":\"oct\",\"kid\":\"org.cryptomator.hub.memberkey\",\"k\":\"MVVPlljNLz9U5RFXL69Ayhio64QL-LtObty1G5kDxuQ\",\"alg\":\"A256KW\"}, {\"kty\":\"EC\",\"d\":\"NTfdwokq1q6qA8FZ-jdZ09LrBY4oI6UHL40_2bQ64HI0KIhGYIOwFGBwX2U50Eei\",\"crv\":\"P-384\",\"kid\":\"org.cryptomator.hub.recoverykey.k60X5s2Jie8fadgmy9HPnv4c_1kEv7qOVdP1j8vKjbA\",\"x\":\"Q_QS3CJbiLqczASmiKbYJtb1sf3nxoKtL6ooH4I-mI9XcygjhDwos6-XfRq_xFh1\",\"y\":\"AF9UnxL6FBolRVfrJw0ZNRBsFYPeqqc98rXdfn8je7HzysDWPQA_XNJ18YJtNPsi\",\"alg\":\"ECDH-ES+A256KW\"}]}\n");
         // protected: {"uvf.spec.version":1,"cty":"json","enc":"A256GCM","crit":["uvf.spec.version"],"jku":"jwks.json","cloud.katta.origin":"https://example.com/gateway/api/vaults/b68b0473-e924-4e3e-aea9-3113bb39f506/uvf/vault.uvf"}
-        final String jwe = "{\"ciphertext\":\"mu1NLt7SrGeIvUp_LQ8MdX8NmrycbsSxkeU5k3eQ93AjXeWrd1yXLGTFknn7Ca37Oa5xUYZ2ghtROxnKPIMI00x_NZNgb29G9Ph8WMhj9xmASmVaJHB8qETT5PpB2InPS-E_cYE1KLuFjSVJh6XxtYaP0TSg-Qp0v-VJAu1zacksdHPzjBHJPYe-brumjV6treU5_6ODgWggvMV_C2fLUWWeDAZRQtl32GEmDQKwbpoxx__UcUeD4VkZs49PEbGXA1xzIraey3dnzCOLlO1N5nZYyEs0RLIxYWicR4zlvS-RJAmO6O0Y8MSC5jlzPChzcPnkF0j2Wf1VcVgKFeqXuwLSQ-09bkGikCHamg3GtGGuzBwZwQEVhEveOv8rB-iFGSLcljUqA0wDNRm8dEEjrED2XcsKyeVSKHBryzdeDDEjED_ZvSf9lQpBHcQoYLCrLKd0bg7lLU-tPgOlHHh2fRhP6_7lBg\",\"protected\":\"eyJ1dmYuc3BlYy52ZXJzaW9uIjoxLCJjdHkiOiJqc29uIiwiZW5jIjoiQTI1NkdDTSIsImNyaXQiOlsidXZmLnNwZWMudmVyc2lvbiJdLCJqa3UiOiJqd2tzLmpzb24iLCJjbG91ZC5rYXR0YS5vcmlnaW4iOiJodHRwczovL2V4YW1wbGUuY29tL2dhdGV3YXkvYXBpL3ZhdWx0cy9iNjhiMDQ3My1lOTI0LTRlM2UtYWVhOS0zMTEzYmIzOWY1MDYvdXZmL3ZhdWx0LnV2ZiJ9\",\"recipients\":[{\"encrypted_key\":\"9tP7Dpr959jxCrfg5GrCxXiiQ24zPn1B_DayRq0_VqGpI7APVhudww\",\"header\":{\"alg\":\"A256KW\",\"kid\":\"org.cryptomator.hub.memberkey\"}},{\"encrypted_key\":\"YjxKzvDtcUV0LCuHFySPGlFIO8my65nn7g740lUp5vmA13jvsg18GQ\",\"header\":{\"epk\":{\"kty\":\"EC\",\"crv\":\"P-384\",\"x\":\"iXoJZC1IZ7gGK8dJ1SILmdVBxA-Z3L22tYtc8mnVD5iP6XhFfZCWZcjm7uomLQ8z\",\"y\":\"_5VK8uZnETmwsn3GGUV0A9AEft9_wGANPaeq6LxUJlGlZzeK4mTrw-Wo0lCG_Gaj\"},\"alg\":\"ECDH-ES+A256KW\",\"kid\":\"org.cryptomator.hub.recoverykey.2ZXISh-HhVaChehjaOZ6_n5Xl20fy6oAIkIrKkmMuNc\"}}],\"tag\":\"uP3byZ9RSicLD19rNfaAbQ\",\"iv\":\"MvlZJ8DvwR9tOWx6\"}";
+        final String jwe = "{\"protected\":\"eyJjdHkiOiJqc29uIiwiY3JpdCI6WyJ1dmYuc3BlYy52ZXJzaW9uIl0sInV2Zi5zcGVjLnZlcnNpb24iOjEsImNsb3VkLmthdHRhLm9yaWdpbiI6Imh0dHBzOi8vZXhhbXBsZS5jb20vYXBpLy92YXVsdHMvMTIzL3V2Zi92YXVsdC51dmYiLCJqa3UiOiJqd2tzLmpzb24iLCJlbmMiOiJBMjU2R0NNIn0\",\"recipients\":[{\"header\":{\"kid\":\"org.cryptomator.hub.memberkey\",\"alg\":\"A256KW\"},\"encrypted_key\":\"oMvz_GY-Lg4XJNvNVEUut4gnvwn-a9k16AysFKnryFp2Wy4lZqZ40g\"},{\"header\":{\"kid\":\"org.cryptomator.hub.recoverykey.k60X5s2Jie8fadgmy9HPnv4c_1kEv7qOVdP1j8vKjbA\",\"alg\":\"ECDH-ES+A256KW\",\"epk\":{\"key_ops\":[],\"ext\":true,\"kty\":\"EC\",\"x\":\"ZjquA9iBhxzIxM23m4cULBgClvJM7GMY-askSvTyLn8Hc8FRIEH8tkms3m19Odsk\",\"y\":\"MJuhBwrpKsG7_S_imlv6R_mDe-3-NBCwiGJk3WhXM3_1vQbH2hxLzo-MTjWf4AaI\",\"crv\":\"P-384\"},\"apu\":\"\",\"apv\":\"\"},\"encrypted_key\":\"gx_ccI0xlDMB7XLVRQlmDMLPlbH70XwimVkeqcWLwdtM_z4XCrwrpg\"}],\"iv\":\"ueBmTvYT_bcEE01a\",\"ciphertext\":\"XG8WBC0kCZDVFGy7t9ARetwDsMQuBcz-M3byQctQDBOszOwGmyYPVM2KOiEPayfe55QyJzHqSYolwPkvf4vS2o_D6JYJ4GA_VvdxIpdaOhl3zE-bAyW2fMpUKY6IFDjQDAs147tO2s_zCtr_q27idRKgdK0T10RwPY-tDmEPrStUS-KqXsim53XW3GNLWjPMUh5jgJQtGeXiGZ5gejC8rTxMBCYcTXORYe4yAf1kzHIuQTgPFQJA93NuQnO5t8Gohdj_YBGmmXwE58h4uIFkYSSayWt1dVEUKrM6xJFb6bshZmO3e0vn0svdpxuadcnA_LsCwh7-73s1m7dP4520O27G2_EaJMwIGhsWNx2mUC17Xco4tnb8xPE00m_oezU2DAEbhVjCmr6dwFLpAtDg9rQ6PFDWEfk\",\"tag\":\"JSGRv9Ygtne4oW1nOaHt0055iiDELleCNlEHm9B6Luk\"}";
         for(JWK key : jwks.getKeys()) {
             final UVFMetadataPayload meta = new HubVaultMetadataUVFProvider(JWEObjectJSON.parse(jwe), new JWKSet(key)).getPayload();
             assertEquals("AES-256-GCM-32k", meta.fileFormat());
             assertEquals("AES-SIV-512-B64URL", meta.nameFormat());
             assertEquals(1, meta.seeds().size());
-            assertEquals("p6zznin4zSGt7gH6T95_kZj6HndpyUdY-1QVfxR2k20", meta.seeds().get("ZO3G9w"));
-            assertEquals("ZO3G9w", meta.initialSeed());
-            assertEquals("ZO3G9w", meta.latestSeed());
-            assertEquals("1STEP-HMAC-SHA512", meta.kdf());
-            assertEquals("pNxWJ5R5TO0mbkmL5pv7M3tAi6Etoh_SK73Q0KvfKMY", meta.kdfSalt());
+            assertEquals("Ltg87d0_EnV8i5Rmnt4r48tMTlKc5q5mTcCkBcL1eXk", meta.seeds().get("WOpxyg"));
+            assertEquals("WOpxyg", meta.initialSeed());
+            assertEquals("WOpxyg", meta.latestSeed());
+            assertEquals("HKDF-SHA512", meta.kdf());
+            assertEquals("Sv9EiiT3ekfuVVWYJw26t28JyOQYi3JOFeQ8vRt-fzQ", meta.kdfSalt());
             assertEquals(true, meta.automaticAccessGrant().getEnabled());
-            assertNull(meta.automaticAccessGrant().getTrustThreshold());
+            assertEquals(1, meta.automaticAccessGrant().getTrustThreshold());
             assertNull(meta.storage());
         }
     }

--- a/hub/src/test/java/cloud/katta/protocols/hub/HubVaultMetadataUVFProviderTest.java
+++ b/hub/src/test/java/cloud/katta/protocols/hub/HubVaultMetadataUVFProviderTest.java
@@ -59,7 +59,7 @@ class HubVaultMetadataUVFProviderTest {
                                 .bucket("bucket")
                 ).withAutomaticAccessGrant(new VaultMetadataAutomaticAccessGrantDto()
                         .enabled(true)
-                        .maxWotDepth(42)
+                        .trustThreshold(42)
                 );
 
         final HubVaultKeys jwks = HubVaultKeys.create();
@@ -101,9 +101,8 @@ class HubVaultMetadataUVFProviderTest {
     void testDecrypt() throws Exception {
         // https://datatracker.ietf.org/doc/html/rfc7516#section-7.2.1
         final JWKSet jwks = JWKSet.parse("{\"keys\":[{\"kty\":\"oct\",\"kid\":\"org.cryptomator.hub.memberkey\",\"k\":\"dp5yWgrqhBNarwOEFDCXKv4h3lUf2pYKCCsXy-6TXDA\",\"alg\":\"A256KW\"}, {\"kty\":\"EC\",\"d\":\"8jz0iHA1jcp2dTB8NkVzTrDjpNhLeqfjLh-6iC2kWpc1VI-tMfK8T7gYjoNDJDDi\",\"crv\":\"P-384\",\"kid\":\"org.cryptomator.hub.recoverykey.2ZXISh-HhVaChehjaOZ6_n5Xl20fy6oAIkIrKkmMuNc\",\"x\":\"C1BXM5oQgz5AsfI7NblbYKMysWO72bQEbXbS7stgypKRxlOn4VQXQ2NkuFu0Ygom\",\"y\":\"7o8Wxe5efN-CXNsm8qe7prohViSl7a4TB8ilF5QHEh2vlIcJ5OXT2MZQyVXUZABo\",\"alg\":\"ECDH-ES+A256KW\"}]}");
+        // protected: {"uvf.spec.version":1,"cty":"json","enc":"A256GCM","crit":["uvf.spec.version"],"jku":"jwks.json","cloud.katta.origin":"https://example.com/gateway/api/vaults/b68b0473-e924-4e3e-aea9-3113bb39f506/uvf/vault.uvf"}
         final String jwe = "{\"ciphertext\":\"mu1NLt7SrGeIvUp_LQ8MdX8NmrycbsSxkeU5k3eQ93AjXeWrd1yXLGTFknn7Ca37Oa5xUYZ2ghtROxnKPIMI00x_NZNgb29G9Ph8WMhj9xmASmVaJHB8qETT5PpB2InPS-E_cYE1KLuFjSVJh6XxtYaP0TSg-Qp0v-VJAu1zacksdHPzjBHJPYe-brumjV6treU5_6ODgWggvMV_C2fLUWWeDAZRQtl32GEmDQKwbpoxx__UcUeD4VkZs49PEbGXA1xzIraey3dnzCOLlO1N5nZYyEs0RLIxYWicR4zlvS-RJAmO6O0Y8MSC5jlzPChzcPnkF0j2Wf1VcVgKFeqXuwLSQ-09bkGikCHamg3GtGGuzBwZwQEVhEveOv8rB-iFGSLcljUqA0wDNRm8dEEjrED2XcsKyeVSKHBryzdeDDEjED_ZvSf9lQpBHcQoYLCrLKd0bg7lLU-tPgOlHHh2fRhP6_7lBg\",\"protected\":\"eyJ1dmYuc3BlYy52ZXJzaW9uIjoxLCJjdHkiOiJqc29uIiwiZW5jIjoiQTI1NkdDTSIsImNyaXQiOlsidXZmLnNwZWMudmVyc2lvbiJdLCJqa3UiOiJqd2tzLmpzb24iLCJjbG91ZC5rYXR0YS5vcmlnaW4iOiJodHRwczovL2V4YW1wbGUuY29tL2dhdGV3YXkvYXBpL3ZhdWx0cy9iNjhiMDQ3My1lOTI0LTRlM2UtYWVhOS0zMTEzYmIzOWY1MDYvdXZmL3ZhdWx0LnV2ZiJ9\",\"recipients\":[{\"encrypted_key\":\"9tP7Dpr959jxCrfg5GrCxXiiQ24zPn1B_DayRq0_VqGpI7APVhudww\",\"header\":{\"alg\":\"A256KW\",\"kid\":\"org.cryptomator.hub.memberkey\"}},{\"encrypted_key\":\"YjxKzvDtcUV0LCuHFySPGlFIO8my65nn7g740lUp5vmA13jvsg18GQ\",\"header\":{\"epk\":{\"kty\":\"EC\",\"crv\":\"P-384\",\"x\":\"iXoJZC1IZ7gGK8dJ1SILmdVBxA-Z3L22tYtc8mnVD5iP6XhFfZCWZcjm7uomLQ8z\",\"y\":\"_5VK8uZnETmwsn3GGUV0A9AEft9_wGANPaeq6LxUJlGlZzeK4mTrw-Wo0lCG_Gaj\"},\"alg\":\"ECDH-ES+A256KW\",\"kid\":\"org.cryptomator.hub.recoverykey.2ZXISh-HhVaChehjaOZ6_n5Xl20fy6oAIkIrKkmMuNc\"}}],\"tag\":\"uP3byZ9RSicLD19rNfaAbQ\",\"iv\":\"MvlZJ8DvwR9tOWx6\"}";
-        final String protectedDecode = new String(Base64.getUrlDecoder().decode("eyJ1dmYuc3BlYy52ZXJzaW9uIjoxLCJjdHkiOiJqc29uIiwiZW5jIjoiQTI1NkdDTSIsImNyaXQiOlsidXZmLnNwZWMudmVyc2lvbiJdLCJqa3UiOiJqd2tzLmpzb24iLCJjbG91ZC5rYXR0YS5vcmlnaW4iOiJodHRwczovL2V4YW1wbGUuY29tL2dhdGV3YXkvYXBpL3ZhdWx0cy9iNjhiMDQ3My1lOTI0LTRlM2UtYWVhOS0zMTEzYmIzOWY1MDYvdXZmL3ZhdWx0LnV2ZiJ9"), StandardCharsets.UTF_8);
-        assertEquals("{\"uvf.spec.version\":1,\"cty\":\"json\",\"enc\":\"A256GCM\",\"crit\":[\"uvf.spec.version\"],\"jku\":\"jwks.json\",\"cloud.katta.origin\":\"https://example.com/gateway/api/vaults/b68b0473-e924-4e3e-aea9-3113bb39f506/uvf/vault.uvf\"}", protectedDecode);
         for(JWK key : jwks.getKeys()) {
             final UVFMetadataPayload meta = new HubVaultMetadataUVFProvider(JWEObjectJSON.parse(jwe), new JWKSet(key)).getPayload();
             assertEquals("AES-256-GCM-32k", meta.fileFormat());
@@ -115,7 +114,7 @@ class HubVaultMetadataUVFProviderTest {
             assertEquals("1STEP-HMAC-SHA512", meta.kdf());
             assertEquals("pNxWJ5R5TO0mbkmL5pv7M3tAi6Etoh_SK73Q0KvfKMY", meta.kdfSalt());
             assertEquals(true, meta.automaticAccessGrant().getEnabled());
-            assertEquals(-1, meta.automaticAccessGrant().getMaxWotDepth());
+            assertNull(meta.automaticAccessGrant().getTrustThreshold());
             assertNull(meta.storage());
         }
     }

--- a/hub/src/test/java/cloud/katta/workflows/AbstractHubSynchronizeTest.java
+++ b/hub/src/test/java/cloud/katta/workflows/AbstractHubSynchronizeTest.java
@@ -356,10 +356,10 @@ abstract class AbstractHubSynchronizeTest extends AbstractHubTest {
 
             // enable automatic access grant, disable WoT verification
             log.info("Enable automatic access grant and disable WoT in {}", adminHubSession);
-            final SettingsDto settings = new SettingsResourceApi(adminHubSession.getClient()).apiSettingsGet();
-            settings.setEnableAutomaticAccessGrant(true);
-            settings.setAllowAutomaticAccessGrantOverride(true);
-            settings.setAutomaticAccessGrantTrustThreshold(-1);
+            final SettingsDto settings = new SettingsResourceApi(adminHubSession.getClient()).apiSettingsGet()
+                    .enableAutomaticAccessGrant(true)
+                    .allowAutomaticAccessGrantOverride(true)
+                    .automaticAccessGrantTrustThreshold(-1);
             new SettingsResourceApi(adminHubSession.getClient()).apiSettingsPut(settings);
 
             {

--- a/hub/src/test/java/cloud/katta/workflows/AbstractHubSynchronizeTest.java
+++ b/hub/src/test/java/cloud/katta/workflows/AbstractHubSynchronizeTest.java
@@ -360,7 +360,6 @@ abstract class AbstractHubSynchronizeTest extends AbstractHubTest {
             settings.setEnableAutomaticAccessGrant(true);
             settings.setAllowAutomaticAccessGrantOverride(true);
             settings.setAutomaticAccessGrantTrustThreshold(-1);
-            settings.setAllowAutomaticAccessGrantOverride(true);
             new SettingsResourceApi(adminHubSession.getClient()).apiSettingsPut(settings);
 
             {

--- a/hub/src/test/java/cloud/katta/workflows/AbstractHubSynchronizeTest.java
+++ b/hub/src/test/java/cloud/katta/workflows/AbstractHubSynchronizeTest.java
@@ -53,11 +53,13 @@ import java.util.UUID;
 
 import cloud.katta.client.ApiException;
 import cloud.katta.client.JSON;
+import cloud.katta.client.api.SettingsResourceApi;
 import cloud.katta.client.api.StorageProfileResourceApi;
 import cloud.katta.client.api.UsersResourceApi;
 import cloud.katta.client.api.VaultResourceApi;
 import cloud.katta.client.model.Role;
 import cloud.katta.client.model.S3StorageClass;
+import cloud.katta.client.model.SettingsDto;
 import cloud.katta.client.model.StorageProfileDto;
 import cloud.katta.client.model.StorageProfileS3STSDto;
 import cloud.katta.client.model.StorageProfileS3StaticDto;
@@ -351,6 +353,16 @@ abstract class AbstractHubSynchronizeTest extends AbstractHubTest {
             final UserDto admin = new UsersResourceApi(adminHubSession.getClient()).apiUsersMeGet(false);
             final UUID vaultId;
             final String name;
+
+            // enable automatic access grant, disable WoT verification
+            log.info("Enable automatic access grant and disable WoT in {}", adminHubSession);
+            final SettingsDto settings = new SettingsResourceApi(adminHubSession.getClient()).apiSettingsGet();
+            settings.setEnableAutomaticAccessGrant(true);
+            settings.setAllowAutomaticAccessGrantOverride(true);
+            settings.setAutomaticAccessGrantTrustThreshold(-1);
+            settings.setAllowAutomaticAccessGrantOverride(true);
+            new SettingsResourceApi(adminHubSession.getClient()).apiSettingsPut(settings);
+
             {
                 // admin creates vault
                 final List<StorageProfileDto> storageProfiles = new StorageProfileResourceApi(adminHubSession.getClient()).apiStorageprofileGet(false);

--- a/hub/src/test/java/cloud/katta/workflows/AbstractHubWorkflowGroupTest.java
+++ b/hub/src/test/java/cloud/katta/workflows/AbstractHubWorkflowGroupTest.java
@@ -31,6 +31,7 @@ import cloud.katta.client.ApiClient;
 import cloud.katta.client.ApiException;
 import cloud.katta.client.JSON;
 import cloud.katta.client.api.GroupsResourceApi;
+import cloud.katta.client.api.SettingsResourceApi;
 import cloud.katta.client.api.StorageProfileResourceApi;
 import cloud.katta.client.api.UsersResourceApi;
 import cloud.katta.client.api.VaultResourceApi;
@@ -39,6 +40,7 @@ import cloud.katta.client.model.GroupDto;
 import cloud.katta.client.model.MemberDto;
 import cloud.katta.client.model.Role;
 import cloud.katta.client.model.S3StorageClass;
+import cloud.katta.client.model.SettingsDto;
 import cloud.katta.client.model.StorageProfileDto;
 import cloud.katta.client.model.StorageProfileS3STSDto;
 import cloud.katta.client.model.StorageProfileS3StaticDto;
@@ -73,6 +75,15 @@ abstract class AbstractHubWorkflowGroupTest extends AbstractHubTest {
             try (InputStream in = Objects.requireNonNull(this.getClass().getResourceAsStream(dockerConfig.envFile))) {
                 configuration.load(in);
             }
+
+            // enable automatic access grant, disable WoT verification
+            log.info("Enable automatic access grant and disable WoT");
+            final SettingsDto settings = new SettingsResourceApi(adminApiClient).apiSettingsGet();
+            settings.setEnableAutomaticAccessGrant(true);
+            settings.setAllowAutomaticAccessGrantOverride(true);
+            settings.setAutomaticAccessGrantTrustThreshold(-1);
+            settings.setAllowAutomaticAccessGrantOverride(true);
+            new SettingsResourceApi(adminApiClient).apiSettingsPut(settings);
 
             log.info("S00 admin uploads storage profile");
             final StorageProfileResourceApi adminStorageProfileApi = new StorageProfileResourceApi(adminApiClient);

--- a/hub/src/test/java/cloud/katta/workflows/AbstractHubWorkflowGroupTest.java
+++ b/hub/src/test/java/cloud/katta/workflows/AbstractHubWorkflowGroupTest.java
@@ -82,7 +82,6 @@ abstract class AbstractHubWorkflowGroupTest extends AbstractHubTest {
             settings.setEnableAutomaticAccessGrant(true);
             settings.setAllowAutomaticAccessGrantOverride(true);
             settings.setAutomaticAccessGrantTrustThreshold(-1);
-            settings.setAllowAutomaticAccessGrantOverride(true);
             new SettingsResourceApi(adminApiClient).apiSettingsPut(settings);
 
             log.info("S00 admin uploads storage profile");

--- a/hub/src/test/java/cloud/katta/workflows/AbstractHubWorkflowTest.java
+++ b/hub/src/test/java/cloud/katta/workflows/AbstractHubWorkflowTest.java
@@ -79,7 +79,6 @@ abstract class AbstractHubWorkflowTest extends AbstractHubTest {
             settings.setEnableAutomaticAccessGrant(true);
             settings.setAllowAutomaticAccessGrantOverride(true);
             settings.setAutomaticAccessGrantTrustThreshold(-1);
-            settings.setAllowAutomaticAccessGrantOverride(true);
             new SettingsResourceApi(adminApiClient).apiSettingsPut(settings);
 
             log.info("S00 admin uploads storage profile");

--- a/hub/src/test/java/cloud/katta/workflows/AbstractHubWorkflowTest.java
+++ b/hub/src/test/java/cloud/katta/workflows/AbstractHubWorkflowTest.java
@@ -30,12 +30,14 @@ import java.util.stream.Collectors;
 import cloud.katta.client.ApiClient;
 import cloud.katta.client.ApiException;
 import cloud.katta.client.JSON;
+import cloud.katta.client.api.SettingsResourceApi;
 import cloud.katta.client.api.StorageProfileResourceApi;
 import cloud.katta.client.api.UsersResourceApi;
 import cloud.katta.client.api.VaultResourceApi;
 import cloud.katta.client.model.MemberDto;
 import cloud.katta.client.model.Role;
 import cloud.katta.client.model.S3StorageClass;
+import cloud.katta.client.model.SettingsDto;
 import cloud.katta.client.model.StorageProfileDto;
 import cloud.katta.client.model.StorageProfileS3STSDto;
 import cloud.katta.client.model.StorageProfileS3StaticDto;
@@ -70,6 +72,15 @@ abstract class AbstractHubWorkflowTest extends AbstractHubTest {
             try (InputStream in = Objects.requireNonNull(this.getClass().getResourceAsStream(dockerConfig.envFile))) {
                 configuration.load(in);
             }
+
+            // enable automatic access grant, disable WoT verification
+            log.info("Enable automatic access grant and disable WoT");
+            final SettingsDto settings = new SettingsResourceApi(adminApiClient).apiSettingsGet();
+            settings.setEnableAutomaticAccessGrant(true);
+            settings.setAllowAutomaticAccessGrantOverride(true);
+            settings.setAutomaticAccessGrantTrustThreshold(-1);
+            settings.setAllowAutomaticAccessGrantOverride(true);
+            new SettingsResourceApi(adminApiClient).apiSettingsPut(settings);
 
             log.info("S00 admin uploads storage profile");
             final StorageProfileResourceApi adminStorageProfileApi = new StorageProfileResourceApi(adminApiClient);

--- a/hub/src/test/java/cloud/katta/workflows/GrantAccessServiceImplTest.java
+++ b/hub/src/test/java/cloud/katta/workflows/GrantAccessServiceImplTest.java
@@ -54,7 +54,7 @@ class GrantAccessServiceImplTest {
         when(vaultServiceMock.getVaultAccessToken(vaultId, aliceKeys)).thenReturn(new UVFAccessTokenPayload(vaultKeys.memberKey()));
         when(vaultServiceMock.getVaultMetadata(vaultId)).thenReturn(
                 JWEObjectJSON.parse(new HubVaultMetadataUVFProvider(new UVFMetadataPayload()
-                        .withAutomaticAccessGrant(new VaultMetadataAutomaticAccessGrantDto().enabled(automaticAccessGrantEnabled).maxWotDepth(maxWotDepth)),
+                        .withAutomaticAccessGrant(new VaultMetadataAutomaticAccessGrantDto().enabled(automaticAccessGrantEnabled).trustThreshold(maxWotDepth)),
                         "apiUrl", vaultId, vaultKeys.serialize()).encrypt()));
         when(wotServiceMock.getTrustLevelsPerUserId(aliceKeys)).thenReturn(Collections.singletonMap(bob.getId(), bobTrustLevel));
 


### PR DESCRIPTION
Closes 

- [x] https://github.com/shift7-ch/katta-clientlib/issues/327

Depends on 

- [x] https://github.com/shift7-ch/katta-server/pull/154

**Changes**
- [x] update openapi.json and Keycloak and Katta server images from upstream
- [x] take defaults from hub settings upon vault creation for automatic access grant and wot level
